### PR TITLE
Add XMPP as a provider

### DIFF
--- a/content/guide/providers.md
+++ b/content/guide/providers.md
@@ -584,6 +584,11 @@ implementations.
       <td>[Pascal Bach](https://github.com/pascal-bach)</td>
     </tr>
     <tr>
+      <td>[XMPP](https://github.com/surevine/passport-xmpp)</td>
+      <td>XMPP</td>
+      <td>[Lloyd Watkin](https://github.com/lloydwatkin)</td>
+    </tr>
+    <tr>
       <td>[Yahoo!](https://github.com/jaredhanson/passport-yahoo)</td>
       <td>OpenID</td>
       <td>[Jared Hanson](https://github.com/jaredhanson)</td>


### PR DESCRIPTION
Wasn't sure which section to put it in, as its a standard not a company. But I've put it under the list of providers anyway.

See https://github.com/jaredhanson/passport/issues/288#issuecomment-56393289
