### PR TITLE
Support monospace fonts when not on a Mac

### DIFF
--- a/public/stylesheets/base-style.styl
+++ b/public/stylesheets/base-style.styl
@@ -134,7 +134,7 @@ pre .xml .cdata
 p
   code
     padding 2px 4px
-    font-family Menlo
+    font-family Menlo, monospace
     color rgba(white,.8)
     background-color rgba(white,.3)
     border-radius 3px
@@ -150,7 +150,7 @@ dd
   line-height 20px
   code
     padding 2px 4px
-    font-family Menlo
+    font-family Menlo, monospace
     color black
     background-color rgba(white,.5)
     border-radius 3px


### PR DESCRIPTION
I :heart: Menlo, but I'm not always on a Mac.  The monospaced inline text shows up as Times on Linux right now.
