### PR TITLE
Adding strategies "local" and "browserid"

### DIFF
--- a/strategies.yaml
+++ b/strategies.yaml
@@ -39,6 +39,8 @@
 -
   name: passport-box
 -
+  name: passport-browserid
+-
   name: passport-bufferapp
 -
   name: passport-chalkable-oauth2
@@ -135,6 +137,8 @@
   name: passport-ktt
 -
   name: passport-linkedin
+-
+  name: passport-local
 -
   name: passport-mailru
   repository: https://github.com/tiberule/passport-mailru


### PR DESCRIPTION
Both of those strategies were created by @jaredhanson and mentioned in the [Passport README](https://github.com/jaredhanson/passport#search-all-strategies) as 2 of 7 "commonly used strategies".  However, neither one of those shows up in the Strategy search results on the [Passport website](http://passportjs.org/).
