### PR TITLE
added passport-lastfm to strategies.yaml

### DIFF
--- a/strategies.yaml
+++ b/strategies.yaml
@@ -134,6 +134,9 @@
 -
   name: passport-ktt
 -
+  name: passport-lastfm
+  repository: https://github.com/kizzlebot/passport-lastfm
+-
   name: passport-linkedin
 -
   name: passport-mailru


### PR DESCRIPTION
added passport-lastfm to strategies.yaml so strategy is listed on www.passportjs.org
