### PR TITLE
Adds a closing parenthesis to the '/auth/google' route

### DIFF
--- a/views/docs/google.md
+++ b/views/docs/google.md
@@ -55,7 +55,7 @@ Use passport.authenticate(), specifying the 'google' strategy, to authenticate r
 //   the user to google.com.  After authorization, Google will redirect the user
 //   back to this application at /auth/google/callback
 app.get('/auth/google',
-  passport.authenticate('google', { scope: 'https://www.google.com/m8/feeds' });
+  passport.authenticate('google', { scope: 'https://www.google.com/m8/feeds' }));
 
 // GET /auth/google/callback
 //   Use passport.authenticate() as route middleware to authenticate the


### PR DESCRIPTION
There's a missing parenthesis in the /auth/google route in the oauth example. This PR adds it.