### PR TITLE
fix(docs): Invalid schema link

### DIFF
--- a/views/docs/profile.md
+++ b/views/docs/profile.md
@@ -6,8 +6,8 @@ user profile information will often be available.  Each service tends to have
 a different way of encoding this information.  To make integration easier,
 Passport normalizes profile information to the extent possible.
 
-Normalized profile information conforms to the [contact schema](http://portablecontacts.net/draft-spec.html#schema)
-established by [Portable Contacts](http://portablecontacts.net/).  The common
+Normalized profile information conforms to the [contact schema][schema]
+established by [Joseph Smarr][schema-author].  The common
 fields available are outlined in the following table.
 
 <dl>
@@ -49,3 +49,6 @@ fields available are outlined in the following table.
 Note that not all of the above fields are available from every service provider.
 Some providers may contain additional information not described here.  Consult
 the provider-specific documentation for further details.
+
+[schema]: https://tools.ietf.org/html/draft-smarr-vcarddav-portable-contacts-00
+[shema-author]: http://josephsmarr.com/


### PR DESCRIPTION
seems like PortableContacts.net has changed owners and no longer maintained by Joseph, according to [Archive.org][archive] the latest draft was still published on Apr 2016.

I've [contacted][tweet] Joseph to clarify, but in the meantime, its best not to link to that domain and reference the IETF link instead.

[archive]: http://web.archive.org/web/20160426223008/http://portablecontacts.net/draft-spec.html
[tweet]: https://twitter.com/AhmadNassri/status/817334438203891712