### PR TITLE
add openid-client to packages

### DIFF
--- a/data/packages/openid-client.yaml
+++ b/data/packages/openid-client.yaml
@@ -1,0 +1,1 @@
+name: openid-client


### PR DESCRIPTION
This PR adds certified [openid-client](https://www.npmjs.com/package/openid-client) with passport support amongst the listed strategies.