### PR TITLE
Fix typo in OAuth 2.0 code

### DIFF
--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -61,7 +61,7 @@ passport.use('provider', new OAuthStrategy({
     accessTokenURL: 'https://www.provider.com/oauth/access_token',
     userAuthorizationURL: 'https://www.provider.com/oauth/authorize',
     consumerKey: '123-456-789',
-    consumerSecret: 'shhh-its-a-secret'
+    consumerSecret: 'shhh-its-a-secret',
     callbackURL: 'https://www.example.com/auth/provider/callback'
   },
   function(token, tokenSecret, profile, done) {


### PR DESCRIPTION
Comma is missing in OAuth 2.0 configuration example