### PR TITLE
Add consistent monospace system font stack

### DIFF
--- a/web/styles/base-style.styl
+++ b/web/styles/base-style.styl
@@ -4,7 +4,7 @@ pre
     background #212121
     display block
     padding 20px
-    font-family Menlo, Courier New
+    font-family SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace
     font-size 13px
     border-radius 3px
     +breakpoint("tablet")
@@ -134,7 +134,7 @@ pre .xml .cdata
 p
   code
     padding 2px 4px
-    font-family Menlo
+    font-family SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace
     color rgba(white,.8)
     background-color rgba(white,.3)
     border-radius 3px
@@ -150,7 +150,7 @@ dd
   line-height 20px
   code
     padding 2px 4px
-    font-family Menlo
+    font-family SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace
     color black
     background-color rgba(white,.5)
     border-radius 3px

--- a/web/styles/components/package.styl
+++ b/web/styles/components/package.styl
@@ -8,7 +8,7 @@
     abbr
       text-decoration: none
     code
-      font-family: Menlo, Courier New
+      font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace
       font-size: 12px
       white-space: nowrap
     

--- a/web/styles/components/window.styl
+++ b/web/styles/components/window.styl
@@ -52,11 +52,11 @@
       max-width 150px
       margin auto
       display block
-      font-family Menlo, Courier New
+      font-family SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace
       font-size 12px
       color #444F5E
   .window-content
-    font-family Menlo, Courier New
+    font-family SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace
     color #333
     font-size 12px
     padding 20px


### PR DESCRIPTION
`pre` and `code` currently only use Menlo and sometimes Courier New. This pull request adds the cross-OS compatible system font stack used by Bootstrap for these monospace elements.

https://www.client9.com/css-system-font-stack-monospace-v2/