### PR TITLE
Add passport-snapchat strategy and documentation

### DIFF
--- a/app/service.js
+++ b/app/service.js
@@ -4,21 +4,21 @@ exports = module.exports = function(repoHandler, logging) {
   var bodyParser = require('body-parser');
   var cookieParser = require('cookie-parser');
   var path = require('path');
-  
-  
+
+
   var service = express();
-  
+
   service.set('views', path.join(__dirname, '../layouts'));
   service.set('view engine', 'pug');
   service.locals.pretty = true;
-  
+
   service.use(logging());
   service.use(bodyParser.json());
   service.use(bodyParser.urlencoded({ extended: false }));
   service.use(cookieParser());
   service.use(express.static(path.join(__dirname, '../public')));
   //service.use(express.static(path.join(__dirname, '../web')));
-  
+
   service.use(redirect({
     // The following set of redirects were defined in the initial commit to this
     // site's repository.  The redirect URLs matching the template `/guide/{document}.html`
@@ -34,6 +34,7 @@ exports = module.exports = function(repoHandler, logging) {
     '/guide/authenticate.html': '/guide/authenticate/',
     '/guide/authorize.html': '/guide/authorize/',
     '/guide/configuration.html': '/guide/configure/',
+    '/guide/snapchat.html': '/guide/snapchat/',
     '/guide/facebook.html': '/guide/facebook/',
     '/guide/google.html': '/guide/google/',
     '/guide/log-out.html': '/guide/logout/',
@@ -57,6 +58,7 @@ exports = module.exports = function(repoHandler, logging) {
     '/guide/authenticate/': '/docs/authenticate/',
     '/guide/authorize/': '/docs/authorize/',
     '/guide/configure/': '/docs/configure/',
+    '/guide/snapchat/': '/docs/snapchat/',
     '/guide/facebook/': '/docs/facebook/',
     '/guide/google/': '/docs/google/',
     '/guide/login/': '/docs/logout/',
@@ -67,7 +69,7 @@ exports = module.exports = function(repoHandler, logging) {
     '/guide/providers/': '/docs/providers/',
     '/guide/twitter/': '/docs/twitter/',
     '/guide/username-password/': '/docs/username-password/',
-    
+
     // The following set of redirects are a workaround for an overly-permissive
     // redirect rule introduced during the redesign by Auth0 in May 2015.
     // When the redesign was launched, the service removed the `/guide/{document}.html`
@@ -79,6 +81,7 @@ exports = module.exports = function(repoHandler, logging) {
     '/docs/authenticate.html': '/docs/authenticate/',
     '/docs/authorize.html': '/docs/authorize/',
     '/docs/configuration.html': '/docs/configure/',
+    '/docs/snapchat.html': '/docs/snapchat/',
     '/docs/facebook.html': '/docs/facebook/',
     '/docs/google.html': '/docs/google/',
     '/docs/log-out.html': '/docs/logout/',
@@ -90,15 +93,15 @@ exports = module.exports = function(repoHandler, logging) {
     '/docs/user-profile.html': '/docs/profile/',
     '/docs/username-password.html': '/docs/username-password/',
   }, 301));
-  
-  
+
+
   service.get('/repo.json', repoHandler);
-  
+
   service.use(express.static(path.join(__dirname, '../www')));
-  
-  
+
+
   service.use(require('../lib/middleware/loadmanifest')(path.join(__dirname, '../manifest.yaml')));
-  
+
   // catch 404 and forward to error handler
   service.use(function(req, res, next) {
     var err = new Error('Not Found');
@@ -129,8 +132,8 @@ exports = module.exports = function(repoHandler, logging) {
       error: {}
     });
   });
-  
-    
+
+
   return service;
 };
 

--- a/content/index.md
+++ b/content/index.md
@@ -6,6 +6,8 @@ description: "Simple, unobtrusive authentication for Node.js"
 authenticationSchemes:
   - name: twitter
     color: "#55acee"
+  - name: snapchat
+    color: "#fffc00"
   - name: facebook
     color: "#3b5998"
   - name: google
@@ -28,4 +30,4 @@ Passport is authentication middleware for [Node.js](https://nodejs.org/).
 Extremely flexible and modular, Passport can be unobtrusively dropped in to any
 [Express](https://expressjs.com/)-based web application.  A comprehensive set of
 strategies support authentication using a [username and password](/docs/username-password/),
-[Facebook](/docs/facebook/), [Twitter](/docs/twitter/), and [more](/packages/).
+[Snapchat](/docs/snapchat/), [Facebook](/docs/facebook/), [Twitter](/docs/twitter/), and [more](/packages/).

--- a/data/packages/_feeds/featured.yaml
+++ b/data/packages/_feeds/featured.yaml
@@ -1,6 +1,8 @@
 -
   name: passport-facebook
 -
+  name: passport-snapchat
+-
   name: passport-http-bearer
 -
   name: passport-google-oauth

--- a/data/packages/passport-snapchat.yaml
+++ b/data/packages/passport-snapchat.yaml
@@ -1,0 +1,2 @@
+name: passport-snapchat
+featured: true

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,6 +13,7 @@
 ### Providers
 
 * [Facebook](facebook.md)
+* [Snapchat](snapchat.md)
 * [Twitter](twitter.md)
 * [Google](google.md)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -455,6 +455,11 @@ implementations.
       <td>[Jared Hanson](https://github.com/jaredhanson)</td>
     </tr>
     <tr>
+      <td>[Snapchat](https://github.com/Snapchat/passport-snapchat)</td>
+      <td>OAuth 2.0</td>
+      <td>[Snapchat](https://github.com/Snapchat)</td>
+    </tr>
+    <tr>
       <td>[SoundCloud](https://github.com/jaredhanson/passport-soundcloud)</td>
       <td>OAuth 2.0</td>
       <td>[Jared Hanson](https://github.com/jaredhanson)</td>

--- a/docs/snapchat.md
+++ b/docs/snapchat.md
@@ -1,0 +1,85 @@
+---
+title: Snapchat
+---
+
+# Snapchat
+
+The Snapchat strategy allows users to log in to a web application using their
+Snapchat account.  Internally, Snapchat authorization works using OAuth 2.0.
+
+Support for Snapchat is implemented by the [passport-snapchat](https://github.com/Snapchat/passport-snapchat)
+module.
+
+## Install
+
+```bash
+$ npm install passport-snapchat
+```
+
+## Configuration
+
+In order to use Snapchat authorization, you must first create an app within the
+[Snap Kit Developer Portal](https://kit.snapchat.com/portal).  Once created, you will then need
+to generate a Confidential OAuth2 Client to be assigned a compatible OAuth2 Client ID and Private Key.
+In addition, your application must also implement a redirect URL, to which the Snapchat accounts page will
+redirect users after they have approved access for your application. This redirect URL will also need to be added
+to the *Redirect URLs* section for your application within the developer portal.
+
+```javascript
+const passport = require('passport');
+const { Strategy: SnapchatStrategy } = require('passport-snapchat');
+
+passport.use(new SnapchatStrategy({
+    clientID: SNAPCHAT_APP_ID,
+    clientSecret: SNAPCHAT_APP_SECRET,
+    callbackURL: "http://example.com/auth/snapchat/callback"
+  },
+  function(accessToken, refreshToken, profile, cb) {
+    User.findOrCreate(..., function (err, user) {
+      if (err) { return done(err); }
+      return done(null, user);
+    });
+  }
+));
+```
+
+The verify callback for Snapchat authorization accepts `accessToken`,
+`refreshToken`, and `profile` arguments.  `profile` will contain user profile
+information provided by Snapchat; refer to
+[Snapchat Profile](https://snapchat.github.io/passport-snapchat/interfaces/snapchatprofile.html) and
+[User Profile](/guide/profile/) for additional information.
+
+Note: For security reasons, the redirection URL must be registered with Snapchat through the developer portal.
+
+## Routes
+
+Two routes are required for Snapchat authorization.  The first route redirects
+the user to Snapchat.  The second route is the URL to which Snapchat will
+redirect the user after they have logged in.
+
+```javascript
+// Redirect the user to Snapchat for authorization.  When complete,
+// Snapchat will redirect the user back to the application at
+//     /auth/snapchat/callback
+app.get('/auth/snapchat', passport.authenticate('snapchat'));
+
+// Snapchat will redirect the user to this URL after approval.  Finish the
+// authorization process by attempting to obtain an access token.  If
+// access was granted, the user will be logged in.  Otherwise,
+// authorization has failed.
+app.get('/auth/snapchat/callback',
+  passport.authenticate('snapchat', { successRedirect: '/',
+                                      failureRedirect: '/login' }));
+```
+
+Note that the URL of the callback route matches that of the `callbackURL` option
+specified when configuring the strategy.
+
+## Link
+
+A link or button can be placed on a web page, allowing one-click login with
+Snapchat.
+
+```xml
+<a href="/auth/snapchat">Login with Snapchat</a>
+```

--- a/layouts/book.pug
+++ b/layouts/book.pug
@@ -1,9 +1,9 @@
 //-
   Book layout
-  
+
   This layout is used when rendering books.  The rendered page contains the
   book's table of contents and a chapter's text.
-  
+
   The table of contents is selectable using a `.toc` class selector.  The
   chapter's text is selectable using a `.chapter` selector.  These selectors
   were chosen to conform to the book microformat, which, while still
@@ -51,6 +51,8 @@ block content
           ul(data-content='')
             li
               a(href='/docs/facebook/', class=(canonicalPath == '/docs/facebook/' ? 'active' : '')) Facebook
+            li
+              a(href='/docs/snapchat/', class=(canonicalPath == '/docs/snapchat/' ? 'active' : '')) Snapchat
             li
               a(href='/docs/twitter/', class=(canonicalPath == '/docs/twitter/' ? 'active' : '')) Twitter
             li

--- a/layouts/book/chapter.pug
+++ b/layouts/book/chapter.pug
@@ -1,9 +1,9 @@
 //-
   Book layout
-  
+
   This layout is used when rendering books.  The rendered page contains the
   book's table of contents and a chapter's text.
-  
+
   The table of contents is selectable using a `.toc` class selector.  The
   chapter's text is selectable using a `.chapter` selector.  These selectors
   were chosen to conform to the book microformat, which, while still
@@ -51,6 +51,8 @@ block content
           ul(data-content='')
             li
               a(href='/docs/facebook/', class=(canonicalPath == '/docs/facebook/' ? 'active' : '')) Facebook
+            li
+              a(href='/docs/snapchat/', class=(canonicalPath == '/docs/snapchat/' ? 'active' : '')) Snapchat
             li
               a(href='/docs/twitter/', class=(canonicalPath == '/docs/twitter/' ? 'active' : '')) Twitter
             li


### PR DESCRIPTION
**Background**
Snapchat recently released [Login Kit for web and server flows](https://docs.snapchat.com/docs/login-kit/#web). Given that Snapchat is a popular application with a large user base, it would be helpful to include it in the documentation for developers that would like to integrate with it. 

**Changes**
- Adds SnapchatStrategy documentation 
- Add `passport-snapchat` to packages