### PR TITLE
Update logout example to use POST request method

### DIFF
--- a/docs/logout.md
+++ b/docs/logout.md
@@ -9,8 +9,11 @@ that can be called from any route handler which needs to terminate a login
 session.  Invoking `logout()` will remove the `req.user` property and clear the
 login session (if any).
 
+It is a good idea to use POST or DELETE requests instead of GET requests for the 
+logout endpoints, in order to prevent accidental or malicious logouts.
+
 ```javascript
-app.get('/logout', function(req, res){
+app.post('/logout', function(req, res){
   req.logout();
   res.redirect('/');
 });


### PR DESCRIPTION
Using GET requests for logout urls might have unexpected consequences. 

See: https://stackoverflow.com/questions/3521290/logout-get-or-post

Resolves https://github.com/jaredhanson/passport/issues/394