### PR TITLE
Fix broken link for delegated authentication (fixes #62)

### DIFF
--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -7,7 +7,7 @@ title: OAuth
 [OAuth](http://oauth.net/) is a standard protocol that allows users to authorize
 API access to web and desktop or mobile applications.  Once access has been
 granted, the authorized application can utilize the API on behalf of the user.
-OAuth has also emerged as a popular mechanism for [delegated authentication](http://hueniverse.com/2009/04/introducing-sign-in-with-twitter-oauth-style-connect/).
+OAuth has also emerged as a popular mechanism for [delegated authentication](https://hueniverse.com/introducing-sign-in-with-twitter-oauth-style-connect-b906c65913bb).
 
 OAuth comes in two primary flavors, both of which are widely deployed.
 


### PR DESCRIPTION
I stumbled upon this while reading the docs.

I ended up finding the new link via archive.org. This page:

https://web.archive.org/web/20160316232740/http://hueniverse.com/2009/04/introducing-sign-in-with-twitter-oauth-style-connect/

shows that `archive.org` received a redirect to `http://hueniverse.com/2009/04/16/introducing-sign-in-with-twitter-oauth-style-connect/`. _That_ url redirects to `https://hueniverse.com/introducing-sign-in-with-twitter-oauth-style-connect-b906c65913bb`, which matches a prior `archive.org` capture that contains the original article:

https://web.archive.org/web/20160322014955/http://hueniverse.com/2009/04/16/introducing-sign-in-with-twitter-oauth-style-connect/