### PR TITLE
added passport-phantauth strategy

### DIFF
--- a/data/packages/passport-phantauth.yaml
+++ b/data/packages/passport-phantauth.yaml
@@ -1,0 +1,1 @@
+name: passport-phantauth


### PR DESCRIPTION
PhantAuth was designed to simplify testing of applications using OpenID Connect authentication by making use of randomly generated users.

By using PhantAuth, you can test applications built on Passport with an unlimited number of test users. It could bring the developers of applications using Passport considerable added value.

To learn more, please visit: https://www.phantauth.net