### PR TITLE
Add passport-microsoft strategy

### DIFF
--- a/data/packages/passport-microsoft.yaml
+++ b/data/packages/passport-microsoft.yaml
@@ -1,0 +1,2 @@
+name: passport-microsoft
+repository: https://github.com/seanfisher/passport-microsoft


### PR DESCRIPTION
Adds passport-microsoft to the strategies list. Already added to Wiki on passport.js repo as well.