### PR TITLE
Update express session configuration options

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -105,7 +105,11 @@ app.configure(function() {
   app.use(express.static('public'));
   app.use(express.cookieParser());
   app.use(express.bodyParser());
-  app.use(express.session({ secret: 'keyboard cat' }));
+  app.use(express.session({ 
+    secret: 'keyboard cat',
+    resave: false,
+    saveUninitialized: false
+  }));
   app.use(passport.initialize());
   app.use(passport.session());
   app.use(app.router);


### PR DESCRIPTION
From the express-session documentation for [resave](https://github.com/expressjs/session#resave) and [saveUninitialized](https://github.com/expressjs/session#saveuninitialized) configuration options, it is clear that the default options have been deprecated. That's why I'm including the recommended default settings when using the session middleware to set up Passport for express applications.