### PR TITLE
Removes Passport-Slack due to project abandonment with critical issues

### DIFF
--- a/data/packages/passport-slack.yaml
+++ b/data/packages/passport-slack.yaml
@@ -1,1 +1,0 @@
-name: passport-slack


### PR DESCRIPTION
This MR removes the link to Passport-Slack from the strategies page due to its abandonment with critical issues.

The text of the NPM page, and the strategy page on passportjs.org reads "This repository is not getting the love it deserves. If you're interested in taking over maintenance or ownership of this repo and npm, please reach me (Mike Pearson) at [github@x0rz.com](mailto:github@x0rz.com)" I attempted to contact the original author via email and GitHub issues to no success. Their domain no longer appears to be active, and their profile shows only one commit within the last 6 years, subtly changing thie plea in the R'EADME. (That commit was 2018.)

Due to lack of support and common bugs, a fork of this repo was created and added to Passport's strategy list 5 years ago. However, since the abandoned one shows up first in the list, and has more downloads per week (likely still due to its position), this is the one that new users choose, not knowing until significant time is wasted. (I say this, having recently went through this journey.)

In order to prevent the strategies page from directing people to an inactive project rather than an active project, I propose removal of passport-slack.