### PR TITLE
Added discord-strategy

### DIFF
--- a/data/packages/discord-strategy.yaml
+++ b/data/packages/discord-strategy.yaml
@@ -1,0 +1,2 @@
+name: discord-strategy
+repository: https://github.com/bjn7/discord-strategy


### PR DESCRIPTION
As 'passport-discord' is no longer maintained, I have created a successor discord-strategy.

This module allows you to authenticate using Discord OAuth2.

Package : https://www.npmjs.com/package/discord-strategy
Repo : https://www.github.com/bjn7/discord-strategy