### PR TITLE
Add VK ID strategy to catalog

### DIFF
--- a/data/packages/passport-vk-id.yaml
+++ b/data/packages/passport-vk-id.yaml
@@ -1,0 +1,2 @@
+name: passport-vk-id
+repository: https://github.com/asedias/passport-vk-id


### PR DESCRIPTION
I have implemented a new VK ID OAuth2 authentication strategy to replace the outdated passport-vkontakte and passport-vk-strategy packages. These older packages are no longer aligned with the current VK API documentation.

This module allows you to authenticate using VK ID OAuth2.

Package : https://www.npmjs.com/package/passport-vk-id
Repo : https://github.com/asedias/passport-vk-id